### PR TITLE
docs: changed columns number from 2 to 4

### DIFF
--- a/masonry-demo/src/js/main.js
+++ b/masonry-demo/src/js/main.js
@@ -115,7 +115,7 @@ const renderTestItems = produits.map((p) =>
 );
 
 masonry({
-	col: 2,
+	col: 4,
 	spaceX: 5,
 	spaceY: 5,
 	renderItems: renderTestItems,


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update masonry initialization in main.js to use 4 columns instead of 2.